### PR TITLE
Added functionality for partial line matching.

### DIFF
--- a/src/main/java/mnm/mods/tabbychat/ChatAddonAntiSpam.java
+++ b/src/main/java/mnm/mods/tabbychat/ChatAddonAntiSpam.java
@@ -1,6 +1,7 @@
 package mnm.mods.tabbychat;
 
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 
 import mnm.mods.tabbychat.api.Channel;
 import mnm.mods.tabbychat.api.listener.ChannelListener;
@@ -14,7 +15,12 @@ public class ChatAddonAntiSpam implements ChannelListener {
 
     @Override
     public void onMessageAdded(MessageAddedToChannelEvent event) {
-        if (TabbyChat.getInstance().generalSettings.antiSpam.getValue() && event.id == 0) {
+
+        boolean prefEnableAntiSpam = TabbyChat.getInstance().generalSettings.antiSpam.getValue();
+        boolean prefPartialMatching = true; //pref to enable partial line matching.
+        int     prefPartialMatchAmount = 10; //percent of characters different between lines, to be considered spam.
+
+        if (prefEnableAntiSpam && event.id == 0) {
             Channel channel = event.channel;
             Counter counter = this.messageMap.get(channel);
             if (counter == null) {
@@ -22,7 +28,7 @@ public class ChatAddonAntiSpam implements ChannelListener {
                 messageMap.put(channel, counter);
             }
             String chat = event.chat.getUnformattedText();
-            if (chat.equals(counter.lastMessage)) {
+            if ((!prefPartialMatching && chat.equals(counter.lastMessage)) || (prefPartialMatching &&  getDifference(chat, counter.lastMessage) <= prefPartialMatchAmount)) {
                 counter.spamCounter++;
                 event.chat.appendText(" [" + counter.spamCounter + "x]");
                 channel.removeMessageAt(0);
@@ -42,4 +48,7 @@ public class ChatAddonAntiSpam implements ChannelListener {
         }
     }
 
+    private int getDifference(String s1, String s2){
+        return StringUtils.getLevenshteinDistance(s1.toLowerCase(), s2.toLowerCase())*100/s1.length();
+    }
 }


### PR DESCRIPTION
Added option to do partial line matching, including the % of characters that differ between lines.

-hookup for "Partial Matching" setting
-hookup for "Partial Matching Amount" setting
Recommended setting of 10% or less. (depends on how many characters in each chat line are from towns, ranks etc)

Possible Additions:
- [ ] Ability to register settings with tabbychat from within the addon
- [ ] Ability to get all addon settings at once, map?
