### PR TITLE
Partial AntiSpam Matching

### DIFF
--- a/src/main/java/mnm/mods/tabbychat/ChatAddonAntiSpam.java
+++ b/src/main/java/mnm/mods/tabbychat/ChatAddonAntiSpam.java
@@ -1,6 +1,7 @@
 package mnm.mods.tabbychat;
 
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 
 import mnm.mods.tabbychat.api.Channel;
 import mnm.mods.tabbychat.api.listener.ChannelListener;
@@ -14,7 +15,12 @@ public class ChatAddonAntiSpam implements ChannelListener {
 
     @Override
     public void onMessageAdded(MessageAddedToChannelEvent event) {
-        if (TabbyChat.getInstance().generalSettings.antiSpam.getValue() && event.id == 0) {
+
+        boolean prefEnableAntiSpam = TabbyChat.getInstance().generalSettings.antiSpam.getValue();
+        boolean prefPartialMatching = TabbyChat.getInstance().generalSettings.antiSpamPartial.getValue();
+        float   prefPartialMatchAmount = TabbyChat.getInstance().generalSettings.antiSpamPartialAmount.getValue();
+
+        if (prefEnableAntiSpam && event.id == 0) {
             Channel channel = event.channel;
             Counter counter = this.messageMap.get(channel);
             if (counter == null) {
@@ -22,7 +28,7 @@ public class ChatAddonAntiSpam implements ChannelListener {
                 messageMap.put(channel, counter);
             }
             String chat = event.chat.getUnformattedText();
-            if (chat.equals(counter.lastMessage)) {
+            if ((!prefPartialMatching && chat.equals(counter.lastMessage)) || (prefPartialMatching &&  getDifference(chat, counter.lastMessage) <= (prefPartialMatchAmount))) {
                 counter.spamCounter++;
                 event.chat.appendText(" [" + counter.spamCounter + "x]");
                 channel.removeMessageAt(0);
@@ -42,4 +48,7 @@ public class ChatAddonAntiSpam implements ChannelListener {
         }
     }
 
+    private float getDifference(String s1, String s2){
+        return StringUtils.getLevenshteinDistance(s1.toLowerCase(), s2.toLowerCase())*100/s1.length();
+    }
 }

--- a/src/main/java/mnm/mods/tabbychat/settings/GeneralSettings.java
+++ b/src/main/java/mnm/mods/tabbychat/settings/GeneralSettings.java
@@ -1,11 +1,9 @@
 package mnm.mods.tabbychat.settings;
 
-import mnm.mods.tabbychat.util.FormattingSerializer;
 import mnm.mods.tabbychat.util.TimeStamps;
+import mnm.mods.tabbychat.util.Translation;
 import mnm.mods.util.SettingValue;
 import net.minecraft.util.EnumChatFormatting;
-
-import com.google.gson.GsonBuilder;
 
 public class GeneralSettings extends TabbySettings {
 
@@ -17,11 +15,13 @@ public class GeneralSettings extends TabbySettings {
     public SettingValue<EnumChatFormatting> timestampColor = new SettingValue<EnumChatFormatting>(
             EnumChatFormatting.WHITE);
     public SettingValue<Boolean> antiSpam = new SettingValue<Boolean>(false);
+    public SettingValue<Boolean> antiSpamPartial = new SettingValue<Boolean>(true);
+    public SettingValue<Float> antiSpamPartialAmount = new SettingValue<Float>(0.08f);    
     public SettingValue<Boolean> unreadFlashing = new SettingValue<Boolean>(true);
     public SettingValue<Boolean> checkUpdates = new SettingValue<Boolean>(true);
 
     public GeneralSettings() {
-        super("general");
+        super(Translation.SETTINGS_GENERAL.translate());
 
         registerSetting("logChat", logChat);
         registerSetting("splitLog", splitLog);
@@ -29,12 +29,9 @@ public class GeneralSettings extends TabbySettings {
         registerSetting("timestampStyle", timestampStyle);
         registerSetting("timestampColor", timestampColor);
         registerSetting("antiSpam", antiSpam);
+        registerSetting("antiSpamPartial", antiSpamPartial);
+        registerSetting("antiSpamPartialAmount", antiSpamPartialAmount);
         registerSetting("unreadFlashing", unreadFlashing);
         registerSetting("checkUpdates", checkUpdates);
-    }
-
-    @Override
-    protected void setupGson(GsonBuilder builder) {
-        builder.registerTypeAdapter(EnumChatFormatting.class, new FormattingSerializer());
     }
 }

--- a/src/main/java/mnm/mods/tabbychat/settings/GeneralSettings.java
+++ b/src/main/java/mnm/mods/tabbychat/settings/GeneralSettings.java
@@ -1,9 +1,11 @@
 package mnm.mods.tabbychat.settings;
 
+import mnm.mods.tabbychat.util.FormattingSerializer;
 import mnm.mods.tabbychat.util.TimeStamps;
-import mnm.mods.tabbychat.util.Translation;
 import mnm.mods.util.SettingValue;
 import net.minecraft.util.EnumChatFormatting;
+
+import com.google.gson.GsonBuilder;
 
 public class GeneralSettings extends TabbySettings {
 
@@ -16,12 +18,12 @@ public class GeneralSettings extends TabbySettings {
             EnumChatFormatting.WHITE);
     public SettingValue<Boolean> antiSpam = new SettingValue<Boolean>(false);
     public SettingValue<Boolean> antiSpamPartial = new SettingValue<Boolean>(true);
-    public SettingValue<Float> antiSpamPartialAmount = new SettingValue<Float>(0.08f);    
+    public SettingValue<Float> antiSpamPartialAmount = new SettingValue<Float>(0.08f); 
     public SettingValue<Boolean> unreadFlashing = new SettingValue<Boolean>(true);
     public SettingValue<Boolean> checkUpdates = new SettingValue<Boolean>(true);
 
     public GeneralSettings() {
-        super(Translation.SETTINGS_GENERAL.translate());
+        super("general");
 
         registerSetting("logChat", logChat);
         registerSetting("splitLog", splitLog);
@@ -33,5 +35,10 @@ public class GeneralSettings extends TabbySettings {
         registerSetting("antiSpamPartialAmount", antiSpamPartialAmount);
         registerSetting("unreadFlashing", unreadFlashing);
         registerSetting("checkUpdates", checkUpdates);
+    }
+
+    @Override
+    protected void setupGson(GsonBuilder builder) {
+        builder.registerTypeAdapter(EnumChatFormatting.class, new FormattingSerializer());
     }
 }


### PR DESCRIPTION
Updated for new TabbyChat beta version.

Includes 2 settings: 
    -partial matching - enables the feature, default true
    -partial matching amount - percent difference of strings to count as a spam match, default 8%
(Not yet applied to GUI)

Tested and working as of this writing.