### PR TITLE
Mark TabbyChat mod as clientSideOnly

### DIFF
--- a/TabbyChat-Forge/src/main/java/mnm/mods/tabbychat/forge/FMLTabbyChat.java
+++ b/TabbyChat-Forge/src/main/java/mnm/mods/tabbychat/forge/FMLTabbyChat.java
@@ -19,7 +19,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 import net.minecraftforge.fml.common.gameevent.TickEvent.RenderTickEvent;
 import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientConnectedToServerEvent;
 
-@Mod(modid = TabbyRef.MOD_ID, name = TabbyRef.MOD_NAME, version = TabbyRef.MOD_VERSION)
+@Mod(modid = TabbyRef.MOD_ID, name = TabbyRef.MOD_NAME, version = TabbyRef.MOD_VERSION, clientSideOnly = true)
 public class FMLTabbyChat extends TabbyChat {
 
     private File tempDir;


### PR DESCRIPTION
 ...so it doesn't crash the server with SideOnly issues when installed on a server.

Makes TabbyChat less of a pain to use in a dev environment too, as I then don't have to remove the mod every time I want to test my server build.