### PR TITLE
Add check for unread flash setting

### DIFF
--- a/src/main/java/mnm/mods/tabbychat/gui/ChatTab.java
+++ b/src/main/java/mnm/mods/tabbychat/gui/ChatTab.java
@@ -58,7 +58,7 @@ public class ChatTab extends GuiButton {
     public void drawComponent(int mouseX, int mouseY) {
         ChannelStatus status = channel.getStatus();
         if (GuiNewChatTC.getInstance().getChatOpen()
-                || (status != null && status.compareTo(ChannelStatus.PINGED) > 0)
+                || (status != null && (status.compareTo(ChannelStatus.PINGED) > 0) && (TabbyChat.getInstance().settings.general.unreadFlashing.get() == true))
                 || TabbyChat.getInstance().settings.advanced.visibility.get() == ChatVisibility.ALWAYS) {
             ILocation loc = getLocation();
             GlStateManager.enableBlend();


### PR DESCRIPTION
Unread tabs will now only flash if the setting is checked. Resolves issue #87 